### PR TITLE
Add prerequisite in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,29 @@ of the items and to control the fan status.
 The `sensors` utility from lm-sensors provides similar data.
 
 
+PREREQUISITE
+============
+
+The i8kmon depends on Tcl and the logger module in tcllib, which may not
+installed by default on your system.
+You can install them depending on your distro.
+
+Ubuntu
+
+    sudo apt install tcl
+    sudo apt install tcllib
+
+Arch Linux
+
+    sudo pacman -S tcl
+    sudo pacman -S tcllib
+
+Gentoo
+
+    sudo emerge --ask dev-lang/tcl
+    sudo emerge --ask dev-tcltk/tcllib
+
+
 COMPILATION
 ===========
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The `sensors` utility from lm-sensors provides similar data.
 PREREQUISITE
 ============
 
-The i8kmon depends on Tcl and the logger module in tcllib, which may not
+i8kutils depends on Tcl and the logger module in tcllib, which may not
 installed by default on your system.
 You can install them depending on your distro.
 


### PR DESCRIPTION
The tcl and logger module which is often contained in tcllib are not install by default in some distro. So I think it's necessary to mention them as prerequisite in README.